### PR TITLE
Disable teacher announcement

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -112,7 +112,7 @@ export default {
         },
         tannouncement: {
           time: () => DEVELOPEMENT_MODE ? 10000 : 1000 * 15,
-          allowed: () => true,
+          allowed: () => false,
         }
       },
     };

--- a/src/App.vue
+++ b/src/App.vue
@@ -108,7 +108,7 @@ export default {
         },
         announcement: {
           time: () => DEVELOPEMENT_MODE ? 10000 : 1000 * 15,
-          allowed: () => true,
+          allowed: () => false,
         },
         tannouncement: {
           time: () => DEVELOPEMENT_MODE ? 10000 : 1000 * 15,


### PR DESCRIPTION
Needs merge for Tuesday morning.

- Disabled announcement made by teachers because of the end of the related poll.